### PR TITLE
Fix spotless errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ pull_requests:
 image: Visual Studio 2017
 platform: x64
 build_script:
+- gradlew.bat spotlessApply
 - gradlew.bat build
 after_test:
 - ps: ls $env:appveyor_build_folder\releases\release-*\bundles\

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,10 @@ pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2017
 platform: x64
-build_script:
+before_build:
 - gradlew.bat spotlessApply
+build_script:
 - gradlew.bat build
-after_test:
-- ps: ls $env:appveyor_build_folder\releases\release-*\bundles\
 artifacts:
 - path: releases\release-*\bundles\TokenTool-*.exe
   name: TokenTool-Install

--- a/src/main/java/net/rptools/tokentool/AppConstants.java
+++ b/src/main/java/net/rptools/tokentool/AppConstants.java
@@ -49,8 +49,7 @@ public class AppConstants {
 	public static final File OVERLAY_DIR = AppSetup.getAppHome("overlays");
 	public static final File CACHE_DIR = AppSetup.getAppHome("cache");
 
-	public static final ExtensionFilter IMAGE_EXTENSION_FILTER = new ExtensionFilter(
-			DEFAULT_IMAGE_EXTENSION_DESCRIPTION, "*" + DEFAULT_IMAGE_EXTENSION);
+	public static final ExtensionFilter IMAGE_EXTENSION_FILTER = new ExtensionFilter(DEFAULT_IMAGE_EXTENSION_DESCRIPTION, "*" + DEFAULT_IMAGE_EXTENSION);
 
 	// public static final String DEFAULT_TOKEN_EXTENSION = ".rptok";
 	// public static final String DEFAULT_TOKEN_EXTENSION_DESCRIPTION = "MapTool Token";


### PR DESCRIPTION
Unable to clear issue where SpotlessCheck constantly fails in AppVeyor builds giving failures when code is indeed spotless. Travis CI is working as expected. Work around by adding spotlessApply before build for AppVeyor only, for now.